### PR TITLE
Always run /graphql on Meteor's default port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ WIP doesn't work
 
 ```
 meteor add apollo
-meteor npm add --save apollo-client apollo-server express http-proxy-middleware
+meteor npm add --save apollo-client apollo-server express
 ```
 
 ## Client
@@ -83,7 +83,6 @@ user(root, args, context) {
 - [`options`](http://docs.apollostack.com/apollo-server/tools.html#apolloServer)
 - `config` may contain any of the following fields:
   - `path`: [Path](http://expressjs.com/en/api.html#app.use) of the GraphQL server. Default: `'/graphql'`.
-  - `port`: Port for the express server to listen on. Default: `4000`.
   - `maxAccountsCacheSizeInMB`: User account ids are cached in memory to reduce the response latency on multiple requests from the same user. Default: `1`.
 
 # Development

--- a/main-server.js
+++ b/main-server.js
@@ -3,6 +3,7 @@ import './check-npm.js';
 import { apolloServer } from 'apollo-server';
 import express from 'express';
 import proxyMiddleware from 'http-proxy-middleware';
+import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import { _ } from 'meteor/underscore';
 
@@ -10,7 +11,6 @@ import { schema, resolvers } from '/imports/api/schema';
 
 const defaultConfig = {
   path: '/graphql',
-  port: 4000,
   maxAccountsCacheSizeInMB: 1
 };
 
@@ -60,11 +60,7 @@ export const createApolloServer = (givenOptions, givenConfig) => {
 
     return options;
   }));
-
-  graphQLServer.listen(config.port, () => console.log(
-    `GraphQL Server is now running on http://localhost:${config.port}`
-  ));
-
+  
   // This redirects all requests to /graphql to our Express GraphQL server
-  WebApp.rawConnectHandlers.use(proxyMiddleware(`http://localhost:${config.port}${config.path}`));
+  WebApp.rawConnectHandlers.use(Meteor.bindEnvironment(graphQLServer));
 }

--- a/main-server.js
+++ b/main-server.js
@@ -2,7 +2,6 @@ import './check-npm.js';
 
 import { apolloServer } from 'apollo-server';
 import express from 'express';
-import proxyMiddleware from 'http-proxy-middleware';
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import { _ } from 'meteor/underscore';

--- a/main-server.js
+++ b/main-server.js
@@ -61,5 +61,5 @@ export const createApolloServer = (givenOptions, givenConfig) => {
   }));
   
   // This redirects all requests to /graphql to our Express GraphQL server
-  WebApp.rawConnectHandlers.use(Meteor.bindEnvironment(graphQLServer));
+  WebApp.connectHandlers.use(Meteor.bindEnvironment(graphQLServer));
 }


### PR DESCRIPTION
Refererence: apollostack/docs#104