### PR TITLE
WIP: Enable calling GraphQL from the server (i.e. in a Meteor.method)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See also this simple usage example: https://github.com/lorensr/meteor-starter-ki
 
 ```
 meteor add apollo
-meteor npm install --save apollo-client apollo-server express
+meteor npm install --save apollo-client apollo-server express graphql graphql-tools
 ```
 
 ## Client

--- a/main-server.js
+++ b/main-server.js
@@ -65,25 +65,23 @@ export const createApolloServer = (givenOptions, givenConfig) => {
   // This redirects all requests to /graphql to our Express GraphQL server
   WebApp.connectHandlers.use(Meteor.bindEnvironment(graphQLServer));
   
-  return {
-    call: async ({ query, variables }) => {
-      // If userId exists, add it to the context.
-      let { userId = null } = this;
-    
-      // Build the schema 
-      const executableSchema = makeExecutableSchema({
-        typeDefs: schema,
-        resolvers,
-        allowUndefinedInResolve: true,
-      });
-    
-      const { data, errors } = await graphql(executableSchema, query, null, { userId }, variables);
-    
-      if (errors) {
-        throw new Error(errors);
-      }
-    
-      return data;
+  return async ({ query, variables }) => {
+    // If userId exists, add it to the context.
+    let { userId = null } = this;
+  
+    // Build the schema 
+    const executableSchema = makeExecutableSchema({
+      typeDefs: schema,
+      resolvers,
+      allowUndefinedInResolve: true,
+    });
+  
+    const { data, errors } = await graphql(executableSchema, query, null, { userId }, variables);
+  
+    if (errors) {
+      throw new Error(errors);
     }
-  }
+  
+    return data;
+  };
 };

--- a/main-server.js
+++ b/main-server.js
@@ -71,8 +71,8 @@ export const createApolloServer = (givenOptions, givenConfig) => {
   
     // Build the schema 
     const executableSchema = makeExecutableSchema({
-      typeDefs: schema,
-      resolvers,
+      typeDefs: config.schema,
+      resolvers: config.resolvers,
       allowUndefinedInResolve: true,
     });
   

--- a/main-server.js
+++ b/main-server.js
@@ -7,6 +7,8 @@ import { WebApp } from 'meteor/webapp';
 import { check } from 'meteor/check';
 import { Accounts } from 'meteor/accounts-base';
 import { _ } from 'meteor/underscore';
+import { makeExecutableSchema } from 'graphql-tools';
+import graphql from 'graphql';
 
 const defaultConfig = {
   path: '/graphql',
@@ -62,4 +64,26 @@ export const createApolloServer = (givenOptions, givenConfig) => {
   
   // This redirects all requests to /graphql to our Express GraphQL server
   WebApp.connectHandlers.use(Meteor.bindEnvironment(graphQLServer));
+  
+  return {
+    call: async ({ query, variables }) => {
+      // If userId exists, add it to the context.
+      let { userId = null } = this;
+    
+      // Build the schema 
+      const executableSchema = makeExecutableSchema({
+        typeDefs: schema,
+        resolvers,
+        allowUndefinedInResolve: true,
+      });
+    
+      const { data, errors } = await graphql(executableSchema, query, null, { userId }, variables);
+    
+      if (errors) {
+        throw new Error(errors);
+      }
+    
+      return data;
+    }
+  }
 };


### PR DESCRIPTION
After having a lot of difficulties trying to fit GraphQL into an existing app that heavily depend on meteor methods, I came up with the idea of calling GraphQL on the server for example from a Meteor.method like so:

```js
import { createApolloServer } from 'meteor/apollo';
import { schema, resolvers } from './schema.js';
import { Meteor } from 'meteor/meteor';
import { gql } from 'apollo-client/gql'; // <-- also, this maybe fits better inside graphql-tools?

const server = createApolloServer({
  graphiql: true,
  pretty: true,
  schema,
  resolvers,
});

Meteor.methods({
  searchBooks(searchString) {
    return server.call(this, {
      query: gql`
        search($q: String!) {
           searchBooks(name: $query) {
              title
              relatedBooks {
                title
              }
           }
        }
      `,
      variables: {
        name: searchString,
      },
    });
  } 
});
```