### PR TITLE
Updating Apollo Server to v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file. [*File syntax*](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.0] - 2016-08-05
+### Updated
+
+- `apollo-server` [v0.2.x](https://github.com/apollostack/apollo-server/blob/cc15ebfb1c9637989e09976c8416b4fd5c2b6728/CHANGELOG.md)
+  - Updated interface to reflect `apollo-server` refactor.
+
 ## [0.1.0] - 2016-07-16
 ### Updated
 

--- a/check-npm.js
+++ b/check-npm.js
@@ -3,11 +3,11 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 if (Meteor.isClient) {
   checkNpmVersions({
-    'apollo-client': '^0.4.0',
+    'apollo-client': '^0.4.11',
   }, 'apollo');
 } else {
   checkNpmVersions({
-    'apollo-server': '^0.1.1',
+    'apollo-server': '^0.2.1',
     'express': '^4.13.4',
   }, 'apollo');
 }

--- a/check-npm.js
+++ b/check-npm.js
@@ -8,6 +8,9 @@ if (Meteor.isClient) {
 } else {
   checkNpmVersions({
     'apollo-server': '^0.2.1',
-    'express': '^4.13.4',
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "graphql": "^0.6.2",
+    "graphql-tools": "^0.6.2",
   }, 'apollo');
 }

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'apollo',
-  version: '0.1.0-beta',
+  version: '0.2.1-beta',
   summary: 'Add Apollo to your Meteor app 🚀',
   git: 'https://github.com/apollostack/meteor-integration'
 });

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'apollo',
-  version: '0.2.1-beta',
+  version: '0.1.0',
   summary: 'Add Apollo to your Meteor app 🚀',
   git: 'https://github.com/apollostack/meteor-integration'
 });


### PR DESCRIPTION
Changed structure according to the migration guide found here: http://docs.apollostack.com/apollo-server/migration.html

Also, changed usgae in two ways -- server export variable now called "startApolloServer" to avoid confusion with "createApolloServer" of previous versions; "startApolloServer" takes three arguments: Apollo arguments (e.g. schema), Apollo server config (e.g. endpoint URL), and finally GraphiQL options.

If no third argument is passed, GraphiQL does not start.