### PR TITLE
Return graphQLServer in createApolloServer

### DIFF
--- a/main-server.js
+++ b/main-server.js
@@ -75,4 +75,6 @@ export const createApolloServer = (givenOptions, givenConfig) => {
 
   // This binds the specified paths to the Express server running Apollo + GraphiQL
   WebApp.connectHandlers.use(Meteor.bindEnvironment(graphQLServer));
+  
+  return graphQLServer
 };


### PR DESCRIPTION
Why not return the graphQLServer when calling createApolloServer? Seems logic to me.

Also, this allows us to do this:

```js
const graphQLServer = createApolloServer({
  graphiql: true,
  pretty: true,
  schema,
  resolvers,
})

graphQLServer.use('*', cors());
```