### PR TITLE
Tested & working: new GraphQL release

### DIFF
--- a/check-npm.js
+++ b/check-npm.js
@@ -10,7 +10,7 @@ if (Meteor.isClient) {
     'apollo-server': '^0.2.1',
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "graphql": "^0.6.2",
+    "graphql": "^0.7.0",
     "graphql-tools": "^0.6.2",
   }, 'apollo');
 }

--- a/main-server.js
+++ b/main-server.js
@@ -28,7 +28,7 @@ const defaultOptions = {
 
 export const createApolloServer = (givenOptions, givenConfig) => {
 
-  let config = _.extend(defaultConfig, givenConfig);
+  let config = Object.assign({}, defaultConfig, givenConfig);
 
   const graphQLServer = express();
 
@@ -43,7 +43,7 @@ export const createApolloServer = (givenOptions, givenConfig) => {
       options = givenOptions;
 
     // Merge in the defaults
-    options = _.extend(defaultOptions, options);
+    options = Object.assign({}, defaultOptions, options);
 
     // Get the token from the header
     if (req.headers.authorization) {

--- a/main-server.js
+++ b/main-server.js
@@ -18,6 +18,14 @@ const defaultConfig = {
   graphiqlOptions : {}
 };
 
+const defaultOptions = {
+  formatError: e => ({ 
+    message: e.message,
+    locations: e.locations,
+    path: e.path
+  }),
+};
+
 export const createApolloServer = (givenOptions, givenConfig) => {
 
   let config = _.extend(defaultConfig, givenConfig);
@@ -34,7 +42,8 @@ export const createApolloServer = (givenOptions, givenConfig) => {
     else
       options = givenOptions;
 
-    options = Object.assign({}, options);
+    // Merge in the defaults
+    options = _.extend(defaultOptions, options);
 
     // Get the token from the header
     if (req.headers.authorization) {


### PR DESCRIPTION
Updated to the latest GraphQL release, which stops the constant warnings being generated in the console output (when using `0.7.0`)