### PR TITLE
Login with current user in GraphiQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## VNEXT
 ### New features
 
-- Automatically pass Meteor authentication in GraphiQL ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#35](https://github.com/apollostack/graphql-tools/pull/35)).
+- Automatically pass Meteor authentication in GraphiQL ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#35](https://github.com/apollostack/meteor-integration/pull/35)).
 
 ## [0.1.0] - 2016-08-05
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## VNEXT
 
 - `apollo-server`
-  - Automatically pass Meteor authentication in GraphiQL.
+  - Automatically pass Meteor authentication in GraphiQL ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#35](https://github.com/apollostack/graphql-tools/pull/35)).
 
 ## [0.1.0] - 2016-08-05
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file. [*File syntax*](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## VNEXT
+
+- `apollo-server`
+  - Automatically pass Meteor authentication in GraphiQL.
+
 ## [0.1.0] - 2016-08-05
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file. [*File synt
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## VNEXT
+### New features
 
-- `apollo-server`
-  - Automatically pass Meteor authentication in GraphiQL ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#35](https://github.com/apollostack/graphql-tools/pull/35)).
+- Automatically pass Meteor authentication in GraphiQL ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#35](https://github.com/apollostack/graphql-tools/pull/35)).
 
 ## [0.1.0] - 2016-08-05
 ### Updated

--- a/main-server.js
+++ b/main-server.js
@@ -15,12 +15,16 @@ const defaultConfig = {
   maxAccountsCacheSizeInMB: 1,
   graphiql : Meteor.isDevelopment,
   graphiqlPath : '/graphiql',
-  graphiqlOptions : {}
+  graphiqlOptions : {
+    passHeader : "'Authorization': localStorage['Meteor.loginToken']"
+  }
 };
 
 export const createApolloServer = (givenOptions, givenConfig) => {
 
+  let graphiqlOptions = _.extend(defaultConfig.graphiqlOptions, givenConfig.graphiqlOptions);
   let config = _.extend(defaultConfig, givenConfig);
+  config.graphiqlOptions = graphiqlOptions;
 
   const graphQLServer = express();
 

--- a/main-server.js
+++ b/main-server.js
@@ -21,7 +21,7 @@ const defaultConfig = {
 };
 
 const defaultOptions = {
-  formatError: e => ({ 
+  formatError: e => ({
     message: e.message,
     locations: e.locations,
     path: e.path
@@ -30,13 +30,9 @@ const defaultOptions = {
 
 export const createApolloServer = (givenOptions, givenConfig) => {
 
-<<<<<<< HEAD
-  let graphiqlOptions = _.extend(defaultConfig.graphiqlOptions, givenConfig.graphiqlOptions);
-  let config = _.extend(defaultConfig, givenConfig);
-  config.graphiqlOptions = graphiqlOptions;
-=======
+  let graphiqlOptions = Object.assign({}, defaultConfig.graphiqlOptions, givenConfig.graphiqlOptions);
   let config = Object.assign({}, defaultConfig, givenConfig);
->>>>>>> apollostack/master
+  config.graphiqlOptions = graphiqlOptions;
 
   const graphQLServer = express();
 


### PR DESCRIPTION
Provides the Meteor authorization header automatically.

This works with https://github.com/apollostack/apollo-server/pull/133

This fixes #29 