### PR TITLE
Fix when no auth header present

### DIFF
--- a/main-server.js
+++ b/main-server.js
@@ -78,6 +78,8 @@ export const createApolloServer = (givenOptions, givenConfig) => {
           options.context.userId = user._id;
         }
       }
+    } else {
+      options.context.userId = null;
     }
 
     return options;


### PR DESCRIPTION
When there was none auth header present, the context would leave the same ```userId``` even if the client is in other device.

I'm working on a create-react-app app with a Meteor backend, only graphql connection, no ws. I'm using meteor accounts through graphql