### PR TITLE
Update createNetworkInterface call for apollo-client@0.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file. [*File syntax*](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## vNEXT
+### Updated
+
+- `apollo-client` [v0.5.x](https://github.com/apollostack/apollo-client/blob/master/CHANGELOG.md)
+- Update createNetworkInterface call to match new signature ([@jasonphillips](https://github.com/jasonphillips) in [#43](https://github.com/apollostack/meteor-integration/pull/43)).
+
 ## [0.1.2] - 2016-10-04
 ### Added
 

--- a/check-npm.js
+++ b/check-npm.js
@@ -3,7 +3,7 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 if (Meteor.isClient) {
   checkNpmVersions({
-    'apollo-client': '^0.4.0 || ^0.3.0',
+    'apollo-client': '^0.5.0',
   }, 'apollo');
 } else {
   checkNpmVersions({

--- a/main-client.js
+++ b/main-client.js
@@ -21,8 +21,8 @@ export const createMeteorNetworkInterface = (givenConfig) => {
   }
 
   // For SSR
-  const url = Meteor.absoluteUrl(path);
-  const networkInterface = createNetworkInterface({ uri: url });
+  const uri = Meteor.absoluteUrl(path);
+  const networkInterface = createNetworkInterface({ uri });
 
   if (config.useMeteorAccounts) {
     networkInterface.use([{

--- a/main-client.js
+++ b/main-client.js
@@ -22,7 +22,7 @@ export const createMeteorNetworkInterface = (givenConfig) => {
 
   // For SSR
   const url = Meteor.absoluteUrl(path);
-  const networkInterface = createNetworkInterface(url);
+  const networkInterface = createNetworkInterface({ uri: url });
 
   if (config.useMeteorAccounts) {
     networkInterface.use([{


### PR DESCRIPTION
I assume this was already in the works, but I'm happy to push it along since I'd really like to have v0.5.x of the client available in Meteor :)

The incompatibility fixed here is just to adjust the call to `createNetworkInterface` so it sends an object with uri, as described here:

apollostack/apollo-client#806
