### PR TITLE
remove addTypenameToSelectionSet

### DIFF
--- a/main-client.js
+++ b/main-client.js
@@ -1,7 +1,6 @@
 import './check-npm.js';
 
 import { createNetworkInterface } from 'apollo-client';
-import { addTypenameToSelectionSet } from 'apollo-client/queries/queryTransform';
 import { Accounts } from 'meteor/accounts-base';
 import { _ } from 'meteor/underscore';
 
@@ -51,7 +50,6 @@ export const createMeteorNetworkInterface = (givenConfig) => {
 export const meteorClientConfig = (networkInterfaceConfig) => {
   return {
     networkInterface: createMeteorNetworkInterface(networkInterfaceConfig),
-    queryTransformer: addTypenameToSelectionSet,
 
     // Default to using Mongo _id, must use _id for queries.
     dataIdFromObject: (result) => {


### PR DESCRIPTION
According to https://github.com/apollostack/apollo-client/blob/90a24bf21c633090c3fd8895c84b3691ea0d7dc4/src/ApolloClient.ts#L175, `addTypenameToSelectionSet` is deprecated.