### PR TITLE
Always provide context

### DIFF
--- a/main-server.js
+++ b/main-server.js
@@ -55,6 +55,12 @@ export const createApolloServer = (givenOptions = {}, givenConfig = {}) => {
 
     // Merge in the defaults
     options = Object.assign({}, defaultOptions, options);
+    if (options.context) {
+      // don't mutate the context provided in options
+      options.context = Object.assign({}, options.context);
+    } else {
+      options.context = {};
+    }
 
     // Get the token from the header
     if (req.headers.authorization) {
@@ -73,13 +79,6 @@ export const createApolloServer = (givenOptions = {}, givenConfig = {}) => {
         const isExpired = expiresAt < new Date();
 
         if (!isExpired) {
-          if (options.context) {
-            // don't mutate the context provided in options
-            options.context = Object.assign({}, options.context);
-          } else {
-            options.context = {};
-          }
-
           options.context.userId = user._id;
           options.context.user = user;
         }


### PR DESCRIPTION
Now, when the user is not found, no context is provided, so when we do ```if (context.userId)``` or something like that it throws an error:

```
Cannot read property 'userId' of undefined
```