### PR TITLE
Network interface defined server-side + allow login token in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## vNEXT
 
+- Export `createMeteorNetworkInterface` and `meteorClientConfig` server-side to allow server-side rendering, accept a `loginToken` option in the config of Apollo Client (for example the cookie from `meteorhacks:fast-render` used for SSR) [#57](https://github.com/apollostack/meteor-integration/pull/57)
+
 ## [0.2.1] - 2016-12-23
 ### Added
 

--- a/main-client.js
+++ b/main-client.js
@@ -37,6 +37,7 @@ export const createMeteorNetworkInterface = (givenConfig) => {
         let currentUserToken = cookieLoginToken || localStorageLoginToken;
 
         // ...a login token has been passed to the config, however the "true" one is different ⚠️
+        // https://github.com/apollostack/meteor-integration/pull/57/files#r96745502
         if (Meteor.isClient && cookieLoginToken && cookieLoginToken !== localStorageLoginToken) {
           // be sure to pass the right token to the request!
           currentUserToken = localStorageLoginToken; 

--- a/main-client.js
+++ b/main-client.js
@@ -27,7 +27,8 @@ export const createMeteorNetworkInterface = (givenConfig) => {
   if (config.useMeteorAccounts) {
     networkInterface.use([{
       applyMiddleware(request, next) {
-        const currentUserToken = Accounts._storedLoginToken();
+        // Accounts._storedLoginToken refers to local storage existing only client-side
+        const currentUserToken = config.loginToken ? config.loginToken : Meteor.isClient ? Accounts._storedLoginToken() : null;
 
         if (!currentUserToken) {
           next();

--- a/main-client.js
+++ b/main-client.js
@@ -2,6 +2,7 @@ import './check-npm.js';
 
 import { createNetworkInterface } from 'apollo-client';
 import { Accounts } from 'meteor/accounts-base';
+import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
 
 const defaultNetworkInterfaceConfig = {
@@ -49,6 +50,7 @@ export const createMeteorNetworkInterface = (givenConfig) => {
 
 export const meteorClientConfig = (networkInterfaceConfig) => {
   return {
+    ssrMode: Meteor.isServer,
     networkInterface: createMeteorNetworkInterface(networkInterfaceConfig),
 
     // Default to using Mongo _id, must use _id for queries.

--- a/main-server.js
+++ b/main-server.js
@@ -10,6 +10,8 @@ import { check } from 'meteor/check';
 import { Accounts } from 'meteor/accounts-base';
 import { _ } from 'meteor/underscore';
 
+export { createMeteorNetworkInterface, meteorClientConfig } from './main-client';
+
 const defaultConfig = {
   path: '/graphql',
   maxAccountsCacheSizeInMB: 1,


### PR DESCRIPTION
Hey!

This PR is intended to fix #56.

I've also added the support for a custom `loginToken` in the config to be able to ssr-ing with an Apollo Client knowing about the current user in its requests. 

The `Accounts._storedLoginToken` fn access to the local storage to grab the token, however as it doesn't exist server-side, we'll be unable to get any token the way it was written before. 

The workaround here if someone is doing SSR with `apollo` meteor package and want to have the current user info pre-loaded is to use `fast-render` and to pass the cookie `meteor_login_token` into the `meteorClientConfig`.

What do you think?

ps: merry christmas 🎄🎉