### PR TITLE
Fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ meteor add apollo
 
 ## Tests
 
-TODO broken, see #3
-
 ```bash
 git clone git@github.com:apollostack/meteor-integration.git
 cd meteor-integration
-meteor test-packages ./ --driver-package practicalmeteor:mocha
-open localhost:3000
+npm install
+npm run test
+open http://localhost:3000
 ```
 
 ## Credits

--- a/check-npm.js
+++ b/check-npm.js
@@ -3,14 +3,14 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 if (Meteor.isClient) {
   checkNpmVersions({
-    'apollo-client': '^0.5.0',
+    'apollo-client': '^0.7.0',
   }, 'apollo');
 } else {
   checkNpmVersions({
-    'graphql-server-express': '^0.4.3',
+    'graphql-server-express': '^0.5.0',
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "graphql": "^0.7.0 || ^0.8.0",
-    "graphql-tools": "^0.8.0",
+    "graphql-tools": "^0.9.0",
   }, 'apollo');
 }

--- a/package.js
+++ b/package.js
@@ -20,6 +20,7 @@ Package.onTest(function(api) {
   api.use(['ecmascript',
            'practicalmeteor:mocha',
            'practicalmeteor:chai',
+           'http',
            'apollo']);
 
   api.mainModule('tests/client.js', 'client');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "apollo-meteor-integration",
+  "version": "0.2.1",
+  "description": " 🚀 Add Apollo to your Meteor app",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "meteor test-packages ./ --driver-package practicalmeteor:mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apollostack/meteor-integration.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/apollostack/meteor-integration/issues"
+  },
+  "homepage": "https://github.com/apollostack/meteor-integration#readme",
+  "dependencies": {
+    "apollo-client": "^0.7.3",
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
+    "graphql": "^0.8.2",
+    "graphql-server-express": "^0.5.0",
+    "graphql-tools": "^0.9.0"
+  }
+}

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,11 +1,31 @@
 import { assert } from 'meteor/practicalmeteor:chai';
-
+import { HTTP } from 'meteor/http';
 import { createApolloServer } from 'meteor/apollo';
 
-describe('server', function() {
+import { makeExecutableSchema } from 'graphql-tools';
 
-  it('works', function() {
-    assert.ok(createApolloServer());
+describe('server', function() {
+  it('works', async function() {
+    
+    // create schema
+    const typeDefs = [`type Query { test(who: String): String }`];
+    const resolvers = { Query: { test: (root, { who }) => `Hello ${who}`, } };
+    const schema = makeExecutableSchema({ typeDefs, resolvers, });
+    
+    // instantiate the apollo server
+    const apolloServer = createApolloServer({ schema, });
+    
+    // send a query to the server
+    const { data: queryResult } = await HTTP.post(Meteor.absoluteUrl('/graphql'), {
+      data: { query: '{ test(who: "World") }' }
+    });
+    
+    expect(queryResult).to.deep.equal({
+      data: {
+        test: 'Hello World'
+      }
+    });
+    
   });
 
 });


### PR DESCRIPTION
Hey @lorensr, it's me again! 😄

This is a PR for #3.

![tests ok](https://d17oy1vhnax1f7.cloudfront.net/items/0g3M2B1z2D1L2f352R1s/Image%202017-01-17%20at%2010.07.01%20AM.png?v=8d14eaa0)

Tests run again by creating a `package.json` with the right dependencies, so we don't have to do `Npm.depends` in `package.js`

I also modified the server-side test as `createApolloServer()` doesn't return anything: the `it works` test create a graphql server with a basic schema, and then we run a query on it, expecting the data to be in the right shape. All credits goes to [one of the graphql-server-express test](https://github.com/apollostack/graphql-server/blob/master/packages/graphql-server-express/src/apolloServerHttp.test.ts#L192-L209) for the inspiration 👍 

There is still a warning output by `checkNpmVersions` in test mode, I tried to remove it by doing like explained here https://github.com/tmeasday/check-npm-versions/issues/7#issuecomment-262985313 but no luck.

What do you think?

Cheers :octocat: 